### PR TITLE
Fix the threads method to accept a date rather than a string

### DIFF
--- a/src/pythreads/api.py
+++ b/src/pythreads/api.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from json import JSONEncoder
 from typing import Any, Dict, List, Literal, Optional, Union
@@ -648,13 +648,18 @@ class API:
 
     async def threads(
         self,
-        since: Optional[str] = None,
-        until: Optional[str] = None,
+        since: Optional[Union[date, str]] = None,
+        until: Optional[Union[date, str]] = None,
         limit: Optional[int] = None,
     ):
         """A paginated list of all threads created by the user
 
         https://developers.facebook.com/docs/threads/threads-media#retrieve-a-list-of-all-a-user-s-threads
+
+        Args:
+            since: [optional] The starting `date` of the time window you are requesting
+            until: [optional] The ending `date` of the time window you are requesting
+            limit: [optional] The maximum number of threads to return. Defaults to 25.
         Returns:
             The JSON response as a dict
 
@@ -687,10 +692,16 @@ class API:
             )
         }
 
+        # Handling string is legacy. Need to deprecate and remove.
         if since:
+            if isinstance(since, date):
+                since = since.isoformat()
             params[PARAMS__SINCE] = since
 
+        # Handling string is legacy. Need to deprecate and remove.
         if until:
+            if isinstance(until, date):
+                until = until.isoformat()
             params[PARAMS__UNTIL] = until
 
         if limit:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import unittest
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
@@ -925,9 +925,10 @@ class APITest(unittest.IsolatedAsyncioTestCase):
         mock_response(mock_get, expected)
         mock_build_graph_api_url.return_value = "https://some-uri.com"
 
-        actual = await self.api.threads(
-            since="2024-05-01", until="2024-06-01", limit=10
-        )
+        since = date(2024, 5, 1)
+        until = date(2024, 6, 1)
+
+        actual = await self.api.threads(since=since, until=until, limit=10)
 
         mock_build_graph_api_url.assert_called_once_with(
             f"{self.credentials.user_id}/threads",


### PR DESCRIPTION
Closes #6 

The threads method to accept a date rather than a string. Maintaining backwards compatibility with string for now, but date is preferred to ensure proper formatting in the request.